### PR TITLE
move runner dependency

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -21,3 +21,4 @@ backports.tempfile  # support in unit tests for py32+ tempfile.TemporaryDirector
 mockldap
 sdb
 atomicwrites==1.1.5
+git+https://github.com/ansible/ansible-runner@master#egg=ansible_runner

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -1,4 +1,3 @@
 git+https://github.com/ansible/ansiconv.git@tower_1.0.0#egg=ansiconv
 git+https://github.com/ansible/django-qsstats-magic.git@py3#egg=django-qsstats-magic
 git+https://github.com/ansible/django-jsonbfield@fix-sqlite_serialization#egg=jsonbfield
-git+https://github.com/ansible/ansible-runner@master#egg=ansible_runner


### PR DESCRIPTION
* So that "default" tower won't get runner via git. Instead, it will get
runner via an RPM
* docker env will source runner master from github
