### PR TITLE
Credential Type Issue, ExtraVars Toggle Issue, Job Results Inert Link

### DIFF
--- a/awx/ui/client/features/output/details.component.js
+++ b/awx/ui/client/features/output/details.component.js
@@ -549,7 +549,7 @@ function getInstanceGroupDetails () {
     let link = `/#/instance_groups/${instanceGroup.id}`;
     if (instanceGroup.is_containerized) {
         label = strings.get('labels.CONTAINER_GROUP');
-        link = `/#/instance_groups/container_group/edit/${instanceGroup.id}`;
+        link = `/#/instance_groups/container_group/${instanceGroup.id}`;
     }
 
     let isolated = null;

--- a/awx/ui/client/src/instance-groups/container-groups/edit-container-group.controller.js
+++ b/awx/ui/client/src/instance-groups/container-groups/edit-container-group.controller.js
@@ -92,7 +92,7 @@ function EditContainerGroupController($rootScope, $scope, $state, models, string
   const podSpecValue = sanitizeVars(EditContainerGroupDataset.data.pod_spec_override);
   const defaultPodSpecValue = sanitizeVars(instanceGroup.model.OPTIONS.actions.PUT.pod_spec_override.default);
 
-  if (podSpecValue && podSpecValue.trim() !== defaultPodSpecValue.trim()) {
+  if ((podSpecValue !== '---') && podSpecValue && podSpecValue.trim() !== defaultPodSpecValue.trim()) {
     vm.form.extraVars.isOpen = true;
   } else {
     vm.form.extraVars.isOpen = false;

--- a/awx/ui/client/src/instance-groups/main.js
+++ b/awx/ui/client/src/instance-groups/main.js
@@ -199,6 +199,7 @@ function InstanceGroupsRun($stateExtender, strings) {
         params: {
             credential_search: {
                 value: {
+                    credential_type__kind: 'kubernetes',
                     order_by: 'name',
                     page_size: 5,
                 },
@@ -228,12 +229,11 @@ function InstanceGroupsRun($stateExtender, strings) {
         resolve: {
             ListDefinition: ['CredentialList', list => list],
             Dataset: ['ListDefinition', 'QuerySet', '$stateParams', 'GetBasePath', (list, qs, $stateParams, GetBasePath) => {
-                const params = {
-                    credential_type__kind: 'kubernetes',
-                };
+
+
                 const searchPath = GetBasePath('credentials');
                 return qs.search(
-                    searchPath, params,
+                    searchPath,
                     $stateParams[`${list.iterator}_search`]
                 );
             }]
@@ -257,6 +257,7 @@ function InstanceGroupsRun($stateExtender, strings) {
                 controllerAs: 'vm'
             }
         },
+
         resolve: {
             resolvedModels: InstanceGroupsResolve,
             EditContainerGroupDataset: ['GetBasePath', 'QuerySet', '$stateParams',
@@ -278,6 +279,7 @@ function InstanceGroupsRun($stateExtender, strings) {
         params: {
             credential_search: {
                 value: {
+                    credential_type__kind: 'kubernetes',
                     order_by: 'name',
                     page_size: 5,
                 },
@@ -304,12 +306,9 @@ function InstanceGroupsRun($stateExtender, strings) {
         resolve: {
             ListDefinition: ['CredentialList', list => list],
             Dataset: ['ListDefinition', 'QuerySet', '$stateParams', 'GetBasePath', (list, qs, $stateParams, GetBasePath) => {
-                const params = {
-                    credential_type__kind: 'kubernetes',
-                };
                 const searchPath = GetBasePath('credentials');
                 return qs.search(
-                    searchPath, params,
+                    searchPath,
                     $stateParams[`${list.iterator}_search`]
                 );
             }]


### PR DESCRIPTION

##### SUMMARY
This PR fixes an issue where the CG link in the job results was inert (https://github.com/ansible/awx/issues/4848).  Now that link navigates the user back to the edit view of that CG.  In the CG modal, the proper credential types are rendered after a user searches for and then clicks `CLEAR ALL` or remove the individual badge for each search item.  Finally, this properly toggles the pod spec override based on what comes back from the api

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
7.0.0
```


##### ADDITIONAL INFORMATION
![jobresultslink](https://user-images.githubusercontent.com/39280967/65899675-38d13880-e382-11e9-99bc-4a182ae77bf5.gif)
![credtype](https://user-images.githubusercontent.com/39280967/65899688-3ff84680-e382-11e9-9c9d-da3c5287395e.gif)

