### PR TITLE
Fix minor syntax error failing AdHocCommands

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -3149,7 +3149,7 @@ class AWXReceptorJob:
         pod_spec_override = {}
         if self.task and self.task.instance.instance_group.pod_spec_override:
             pod_spec_override = parse_yaml_or_json(
-                self.task.instance_group.pod_spec_override)
+                self.task.instance.instance_group.pod_spec_override)
         pod_spec = {**default_pod_spec, **pod_spec_override}
 
         if self.task:


### PR DESCRIPTION
easy fix

```
result_traceback:
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 1425, in run
    res = receptor_job.run()
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 3036, in run
    params=self.receptor_params)
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 3096, in receptor_params
    spec_yaml = yaml.dump(self.pod_definition, explicit_start=True)
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 3152, in pod_definition
    self.task.instance_group.pod_spec_override)
AttributeError: 'RunAdHocCommand' object has no attribute 'instance_group'
```