### PR TITLE
Make sure project updates run in default EE

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1394,7 +1394,7 @@ class ProjectSerializer(UnifiedJobTemplateSerializer, ProjectOptionsSerializer):
 
     class Meta:
         model = Project
-        fields = ('*', 'organization', 'scm_update_on_launch',
+        fields = ('*', '-execution_environment', 'organization', 'scm_update_on_launch',
                   'scm_update_cache_timeout', 'allow_override', 'custom_virtualenv', 'default_environment') + \
                  ('last_update_failed', 'last_updated')  # Backwards compatibility
 

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -187,6 +187,14 @@ class ProjectOptions(models.Model):
                 pass
         return cred
 
+    def resolve_execution_environment(self):
+        """
+        Project updates, themselves, will use the default execution environment.
+        Jobs using the project can use the default_environment, but the project updates
+        are not flexible enough to allow customizing the image they use.
+        """
+        return self.get_execution_environment_default()
+
     def get_project_path(self, check_if_exists=True):
         local_path = os.path.basename(self.local_path)
         if local_path and not local_path.startswith('.'):


### PR DESCRIPTION
We don't want to allow users to customize the EE for project updates.

We didn't allow this for custom virtual environments.

So we use the global default, because that might be upstream or downstream, we don't know so we just use the default.

this will need docs.

Ping @jbradberry